### PR TITLE
update almalinux docker repository

### DIFF
--- a/Dockerfile.almalinux8
+++ b/Dockerfile.almalinux8
@@ -1,4 +1,4 @@
-FROM almalinux/almalinux:8
+FROM almalinux:8
 ENV HOME /
 RUN dnf update -y
 RUN dnf install -y rpm-build redhat-rpm-config rpmdevtools gcc-c++ tar make openssl-devel zlib-devel pcre-devel


### PR DESCRIPTION
almalinux/almalinux is deprecated.

> https://hub.docker.com/r/almalinux/almalinux
> DEPRECATION NOTICE: This image is deprecated in favor of the official AlmaLinux OS Docker Image.

use almalinux instead of it.
https://hub.docker.com/_/almalinux